### PR TITLE
Fix typo in grammarkit check

### DIFF
--- a/lib/generated.js
+++ b/lib/generated.js
@@ -194,7 +194,7 @@ class Generated {
     if (this.lines.length <= 1) {
       return false
     }
-    return this.lines[0].StartsWith("// This is a generated file. Not intended for manual editing.")
+    return this.lines[0].startsWith("// This is a generated file. Not intended for manual editing.")
   }
 
   isGeneratedRoxygen2() {

--- a/test/lib/generated.js
+++ b/test/lib/generated.js
@@ -83,6 +83,9 @@ describe('Generated', function() {
 
       // pkgdown-generateed HTML
       assert.ok(helper.isGenerated("HTML/pkgdown.html"))
+
+      // java grammarkit
+      assert.ok(helper.isGenerated("Java/GrammarKit.java"))
     });
   });
 });


### PR DESCRIPTION
### Goals
Make java files measurable

### Changes
Fixed a typo in generated.js `StartsWith` -> `startsWith`.
Added a test verifying the fix.